### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,5 @@
+eda:
+  type: kicad
+  pcb: hw/XassetteAsterisk.kicad_pcb
+bom: docs/BOM.csv
+color: white


### PR DESCRIPTION
Hi, this adds a file that allows us to create a [kitspace.org](https://kitspace.org) page for your project.  Kitspace tries to make it easier for people to build OSHW electronics projects. Here is a preview of what the page will look like: http://try-xassette.preview.kitspace.org/boards/github.com/kitspace-forks/Xassette-Asterisk/

Some things to note:

- If you merge this, the Kitspace page will be created under your name and it will keep staying in sync with your repo automatically (re-syncs every 3 hours or so)
-  If you want to improve the BOM, we also have an editor, called the [BOM Builder](https://kitspace.org/bom-builder), that helps you select purchasable parts. I can give you free access if you are interested. 

